### PR TITLE
Introduce type `SuperPixel` and remove type `Pixel`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ ImageCore = ">=0.8.5"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Suppressor"]

--- a/src/SuperPixels.jl
+++ b/src/SuperPixels.jl
@@ -11,7 +11,7 @@ include("synthesize.jl")
 export
     SuperPixel, color, position,
     # utils
-    image_size,
+    imsize,
     # algorithms
     synthesize, Raw, Average
 

--- a/src/SuperPixels.jl
+++ b/src/SuperPixels.jl
@@ -1,7 +1,6 @@
 module SuperPixels
 
 using ImageCore, ColorVectorSpace
-using ImageCore: GenericImage
 using Statistics
 import ColorTypes: color_type, color
 import Base: position
@@ -10,10 +9,9 @@ include("types.jl")
 include("synthesize.jl")
 
 export
-    # Types
-    Pixel, SuperPixel, SuperPixelImage,
+    SuperPixel, color, position,
     # utils
-    color, position, image_size,
+    image_size,
     # algorithms
     synthesize, Raw, Average
 

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -25,24 +25,32 @@ are [`Raw`](@ref) and [`Average`](@ref). The default value is `Raw`.
     Overlaps between superpixels are averaged. Empty pixels are filled
     by zeros.
 """
-synthesize(img::SuperPixelImage, method = Raw()) = synthesize(color_type(img), img, method)
-synthesize(::Type{T}, img::SuperPixelImage, method = Raw()) where T = synthesize(T, img, method)
+synthesize(img::AbstractArray{<:SuperPixel}, method = Raw()) =
+    synthesize(color_type(img), img, method)
+synthesize(::Type{T}, img::AbstractArray{<:SuperPixel}, method = Raw()) where T =
+    synthesize(T, img, method)
 
-function synthesize(::Type{CT}, img::SuperPixelImage, ::Raw) where CT <: Union{AbstractRGB, AbstractGray}
+function synthesize(::Type{CT},
+                    img::AbstractArray{<:SuperPixel},
+                    ::Raw) where CT <: Union{AbstractRGB, AbstractGray}
+
     out = zeros(CT, image_size(img))
     count = zeros(Int, image_size(img)) # overlap count
     for SP in img
         isempty(SP) && continue
-        R = position.(SP)
-        out[R] .+= color.(SP)
+        R = position(SP)
+        out[R] .+= color(SP)
         count[R] .+= 1
     end
     return out./count
 end
 
-function synthesize(::Type{CT}, img::SuperPixelImage, ::Average) where CT <: Union{AbstractRGB, AbstractGray}
+function synthesize(::Type{CT},
+                    img::AbstractArray{<:SuperPixel},
+                    ::Average) where CT <: Union{AbstractRGB, AbstractGray}
     averaged_img = map(img) do SP
-        Pixel.(mean(color.(SP)), position.(SP))
+        SuperPixel(fill(mean(SP.color), size(SP.color)),
+                   position(SP))
     end
     return synthesize(CT, averaged_img, Raw())
 end

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -34,8 +34,8 @@ function synthesize(::Type{CT},
                     img::AbstractArray{<:SuperPixel},
                     ::Raw) where CT <: Union{AbstractRGB, AbstractGray}
 
-    out = zeros(CT, image_size(img))
-    count = zeros(Int, image_size(img)) # overlap count
+    out = zeros(CT, imsize(img))
+    count = zeros(Int, imsize(img)) # overlap count
     for SP in img
         isempty(SP) && continue
         R = position(SP)

--- a/src/types.jl
+++ b/src/types.jl
@@ -90,13 +90,13 @@ color_type(img::AbstractArray{<:SuperPixel}) = color_type(eltype(img))
 color_type(::Type{<:SuperPixel{CT}}) where CT <: Colorant = CT
 
 """
-    image_size(img)
+    imsize(img)
 
 Returns the size of potential image represented by [`SuperPixel`](@ref).
 """
-image_size(img::AbstractArray{<:SuperPixel}) = _size(Iterators.flatten(position.(img)))
-image_size(img::SuperPixel) = _size(position(img))
-image_size(img::AbstractArray) = size(img)
+imsize(img::AbstractArray{<:SuperPixel}) = _size(Iterators.flatten(position.(img)))
+imsize(img::SuperPixel) = _size(position(img))
+imsize(img::AbstractArray) = size(img)
 function _size(R)
     I_first, I_last = extrema(R)
     return I_last.I .- I_first.I .+ (1, 1)

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,65 +1,103 @@
-abstract type AbstractPixel end
-
 """
-    Pixel{CT<:Colorant} <: AbstractPixel
+    SuperPixel(pixels, pos)
+    SuperPixel(img, pos)
 
-A pixel holds both color and spatial information.
+A super pixel is a collection of pixels with their position information.
 
-Use [`color`](@ref) and [`position`](@ref) to get the color
-and spatial information of `Pixel`.
+# Fields
+
+* `color::AbstractArray{<:Colorant}` stores its pixel/color information.
+* `position::CartesianIndices` stores its position information.
+
+Relative order in `color` and `position` is important; `color[idx]` is the
+image pixel at position `position[idx]`.
+
+!!! tip
+
+    There's a helper for each field. For example, `color(sp)` is equivalent to
+    `sp.color`. This is useful to enable broadcasting such as `position.(img)`
+    where `img` is a `SuperPixel` array.
+
+# Examples
+
+There're various ways to generate a superpixel at `img[1:2, 3:4]`:
+
+```julia
+img = rand(Gray, 4, 4)
+
+SuperPixel(img, (1:2, 3:4))
+
+pos = CartesianIndices(1:2, 3:4)
+SuperPixel(img[pos], pos)
+```
+
+!!! note
+
+    Each pixel in a superpixel is a `Colorant`; `Number` is promoted to `Gray`
+    when constructing a `SuperPixel` object.
+
+An array of `SuperPixel`s can be treated as an image, you can use [`synthesize`](@ref)
+to generate the potential image contents.
+
+```julia
+img = rand(Gray, 4, 4)
+
+img_sp = [SuperPixel(img, (1:2, 1:2)),
+          SuperPixel(img, (1:2, 3:4)),
+          SuperPixel(img, (3:4, 1:2)),
+          SuperPixel(img, (3:4, 3:4))]
+
+segments = [(1:2, 1:2), (1:2, 3:4), (3:4, 1:2), (3:4, 3:4)]
+img_sp = [SuperPixel(img, pos) for pos in segments]
+
+synthesize(img_sp) # composite superpixels into a complete image
+synthesize(img_sp, Average()) # each superpixel is averaged first
+```
 """
-struct Pixel{CT<:Colorant} <: AbstractPixel
-    color::CT
-    pos::CartesianIndex
-end
-Pixel(gray::Number, pos) = Pixel(Gray(gray), pos)
-Pixel(color::Colorant, pos::Tuple) = Pixel(color, CartesianIndex(pos))
+struct SuperPixel{T<:Colorant, N, AT<:AbstractArray{T}}
+    color::AT
+    position::CartesianIndices{N}
 
-color(p::Pixel) = p.color
-position(p::Pixel) = p.pos
-
-"""
-    SuperPixel{T<:AbstractPixel, N} = AbstractArray{T, N}
-
-A super pixel is a collection of [`Pixel`](@ref)s, where each pixel holds
-both color and spatial information.
-"""
-const SuperPixel{T<:AbstractPixel, N} = AbstractArray{T, N}
-
-"""
-    SuperPixelImage{T<:SuperPixel, N} = AbstractArray{T, N}
-
-A super pixel image is a collection of super pixels [`SuperPixel`](@ref).
-"""
-const SuperPixelImage{T<:SuperPixel, N} = AbstractArray{T, N}
-
-PixelCollection = Union{SuperPixel, SuperPixelImage}
-
-color_type(sp::Union{Pixel, PixelCollection}) = color_type(typeof(sp))
-color_type(::Type{Pixel{CT}}) where CT<:Colorant = CT
-color_type(::Type{T}) where T <: SuperPixel = color_type(eltype(T))
-color_type(::Type{T}) where T<:SuperPixelImage = color_type(eltype(T))
-
-
-# see issue: https://github.com/JuliaLang/julia/issues/33274
-function Base.intersect(s::SuperPixel, itrs...)
-    if isempty(itrs)
-        return s
-    else
-        o = first(itrs)
-        idx = intersect(position.(s), position.(o))
-        return intersect(s[idx], itrs[2:end]...)
+    function SuperPixel{T, N, AT}(
+            color::AT,
+            position::CartesianIndices{N}) where {
+                T<:Colorant, N,
+                AT<:AbstractArray{T}}
+        color = length(color) == length(position) ? color : color[position]
+        new(color, position)
     end
 end
+
+SuperPixel(color::AT, position::CartesianIndices{N}) where {
+        T<:Colorant, N, AT<:AbstractArray{T}} =
+    SuperPixel{T, N, AT}(color, position)
+
+SuperPixel(color::AbstractArray{<:Colorant}, pos::Tuple) =
+    SuperPixel(color, CartesianIndices(pos))
+
+SuperPixel(pixels::AbstractArray{<:Number}, pos) =
+    SuperPixel(Gray.(pixels), pos)
+
+color(sp::SuperPixel) = sp.color
+position(sp::SuperPixel) = sp.position
+
+
+Base.isempty(sp::SuperPixel) = isempty(color(sp))
+Base.:(==)(x::SuperPixel, y::SuperPixel) = x.position == y.position && x.color == y.color
+
+color_type(sp::SuperPixel{CT}) where CT <: Colorant = CT
+color_type(img::AbstractArray{<:SuperPixel}) = color_type(eltype(img))
+color_type(::Type{<:SuperPixel{CT}}) where CT <: Colorant = CT
 
 """
     image_size(img)
 
 Returns the size of potential image represented by [`SuperPixel`](@ref).
 """
-function image_size(img::SuperPixelImage)
-    R = position.(Iterators.flatten(img))
+image_size(img::AbstractArray{<:SuperPixel}) = _size(Iterators.flatten(position.(img)))
+image_size(img::SuperPixel) = _size(position(img))
+image_size(img::AbstractArray) = size(img)
+function _size(R)
     I_first, I_last = extrema(R)
     return I_last.I .- I_first.I .+ (1, 1)
 end
-image_size(img::GenericImage) = size(img)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,14 @@
-using SuperPixels, ImageCore
-using Test
+using ImageCore
+using Test, Suppressor
+
+refambs = @suppress_out detect_ambiguities(ImageCore, Base)
+using SuperPixels
+ambs = @suppress_out detect_ambiguities(ImageCore, Base, SuperPixels)
 
 @testset "SuperPixels.jl" begin
+    # check if SuperPixels.jl introduces new ambiguities
+    @test isempty(setdiff(ambs, refambs))
+
     include("types.jl")
     include("synthesize.jl")
 end

--- a/test/synthesize.jl
+++ b/test/synthesize.jl
@@ -1,18 +1,28 @@
 @testset "conversion" begin
     img = rand(Gray{Float32}, 4, 4)
-    pixels = Pixel.(img, CartesianIndices(img))
-    img_sp = [pixels[1:2, 1:2], pixels[1:2, 3:4], pixels[3:4, 1:2], pixels[3:4, 3:4]]
+    img_sp = [SuperPixel(img, (1:2, 1:2)),
+              SuperPixel(img, (1:2, 3:4)),
+              SuperPixel(img, (3:4, 1:2)),
+              SuperPixel(img, (3:4, 3:4))]
     @test img == synthesize(img_sp)
     @test img == synthesize(img_sp, Raw())
     @test img == synthesize(Gray{Float32}, img_sp)
     @test img == synthesize(Gray{Float32}, img_sp, Raw())
     @test RGB{Float32}.(img) == synthesize(RGB{Float32}, img_sp)
 
-    img_sp = [pixels[1:2, 1:2], pixels[3:4, 1:2], pixels[1:2, 3:4], pixels[3:4, 3:4]] # order independent
+    # order independent
+    img_sp = [SuperPixel(img, (1:2, 1:2)),
+              SuperPixel(img, (3:4, 1:2)),
+              SuperPixel(img, (1:2, 3:4)),
+              SuperPixel(img, (3:4, 3:4))]
     @test img == synthesize(img_sp, Raw())
     @test_nowarn synthesize(img_sp, Average())
 
-    img_sp = [pixels[1:3, 1:3], pixels[1:2, 3:4], pixels[2:4, 1:3], pixels[3:4, 3:4]] # overlap
+    # overlap
+    img_sp = [SuperPixel(img, (1:2, 1:2)),
+              SuperPixel(img, (1:2, 3:4)),
+              SuperPixel(img, (2:4, 1:3)),
+              SuperPixel(img, (3:4, 3:4))]
     @test img == synthesize(img_sp, Raw())
     @test_nowarn synthesize(img_sp, Average())
 end

--- a/test/types.jl
+++ b/test/types.jl
@@ -22,6 +22,21 @@
             @test position(sp1) == sp1.position
 
             @test isempty(sp1) == isempty(sp1.color)
+            @test imsize(sp1) == size(pos)
+            @test color_type(sp1) == (T <: Number ? Gray{T} : T)
+        end
+    end
+
+    @testset "SuperPixel image" begin
+        for T in (Lab{Float32}, RGB{Float32}, Gray{Float32}, Float32)
+            img = rand(T, 4, 4)
+            img_sp = [SuperPixel(img, (1:2, 1:2)),
+                      SuperPixel(img, (1:2, 3:4)),
+                      SuperPixel(img, (3:4, 1:2)),
+                      SuperPixel(img, (3:4, 3:4))]
+
+            @test imsize(img_sp) == size(img)
+            @test color_type(img_sp) == (T <: Number ? Gray{T} : T)
         end
     end
 end

--- a/test/types.jl
+++ b/test/types.jl
@@ -1,37 +1,27 @@
-@testset "Types" begin
-    @testset "Pixel" begin
-        p = Pixel(Gray(0), (1, 1))
-
-        @test_throws MethodError Pixel(rand(Gray))
-        @test p == Pixel(Gray(0), CartesianIndex(1, 1))
-        @test p == Pixel(0, (1, 1))
-    end
-
+@testset "Type" begin
     @testset "SuperPixel" begin
         for T in (Lab{Float32}, RGB{Float32}, Gray{Float32}, Float32)
             img = rand(T, 4, 4)
 
-            # Although conceptually, an image is a large super pixel,
-            # it isn't a SuperPixel type
-            @test !(img isa SuperPixel)
-            @test Pixel.(img, CartesianIndices(img)) isa SuperPixel
-        end
-    end
+            pos = (1:2, 3:4)
+            sp1 = SuperPixel(img, pos)
+            sp2 = SuperPixel(img[pos...], pos)
 
-    @testset "SuperPixelImage" begin
-        for T in (Lab{Float32}, RGB{Float32}, Gray{Float32}, Float32)
-            img = rand(T, 4, 4)
-            pixels = Pixel.(img, CartesianIndices(img))
-            SP_1 = pixels[1:3, 1:3]
-            SP_2 = pixels[1:3, 4]
-            SP_3 = pixels[4, 1:2]
-            SP_4 = pixels[4, 3:4]
-            img_sp = [SP_1, SP_2, SP_3, SP_4]
+            pos = CartesianIndices(pos)
+            sp3 = SuperPixel(img, pos)
+            sp4 = SuperPixel(img[pos], pos)
 
-            # Although conceptually, an image is a large super pixel,
-            # it isn't a SuperPixelImage type
-            @test !(img isa SuperPixelImage)
-            @test img_sp isa SuperPixelImage
+            @test eltype(sp1.color) <: Colorant # Number is promoted to Gray
+            @test size(sp1.color) == size(sp1.position)
+            @test sp1.color == img[sp1.position] # relative order is perserved
+            @test sp2 == sp1
+            @test sp3 == sp1
+            @test sp4 == sp1
+
+            @test color(sp1) == sp1.color
+            @test position(sp1) == sp1.position
+
+            @test isempty(sp1) == isempty(sp1.color)
         end
     end
 end


### PR DESCRIPTION
Changes:

* `Pixel` is replaced by `Colorant`.
* `SuperPixel` is a new type rather than type alias.

This redesign aims to solve two issues:

* arithmetic on `Array{<:Pixel}` is slower because of memory layout
* we need a non-array type for `SuperPixel` to clear the dispatch rules.

About arithmetic, no overhead is observed if we split `color` and `position` into two arrays since both are read from memory contiguously.

```julia
julia> img = rand(Gray, 1024, 1024);
julia> sp = SuperPixel(img, CartesianIndices(img));
julia> Base.:+(x::SuperPixel, y::SuperPixel) = SuperPixel(x.color+y.color, x.position)

julia> @benchmark img .+ img
BenchmarkTools.Trial: 
  memory estimate:  8.00 MiB
  allocs estimate:  4
  --------------
  minimum time:     1.619 ms (0.00% GC)
  median time:      1.659 ms (0.00% GC)
  mean time:        2.403 ms (30.00% GC)
  maximum time:     66.718 ms (97.31% GC)
  --------------
  samples:          2069
  evals/sample:     1

julia> @benchmark sp + sp
BenchmarkTools.Trial: 
  memory estimate:  8.00 MiB
  allocs estimate:  4
  --------------
  minimum time:     1.607 ms (0.00% GC)
  median time:      1.661 ms (0.00% GC)
  mean time:        2.415 ms (30.34% GC)
  maximum time:     64.814 ms (97.37% GC)
  --------------
  samples:          2061
  evals/sample:     1