### PR TITLE
add enforce connectivity feature in analyze method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,14 +8,15 @@ ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageDraw = "4381153b-2b60-58ae-a1ba-fd683676385f"
+Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 ImageCore = ">=0.8.5"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Suppressor"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,14 +4,15 @@ authors = ["Johnny Chen <johnnychen94@hotmail.com>"]
 version = "0.0.1"
 
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageDraw = "4381153b-2b60-58ae-a1ba-fd683676385f"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [compat]
 ImageCore = ">=0.8.5"

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ ImageDraw = "4381153b-2b60-58ae-a1ba-fd683676385f"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [compat]
 ImageCore = ">=0.8.5"

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageDraw = "4381153b-2b60-58ae-a1ba-fd683676385f"
+ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 

--- a/demo.jl
+++ b/demo.jl
@@ -1,0 +1,7 @@
+using Images, ImageCore
+include("src/Superpixels.jl")
+
+input_image = load("lenna.bmp")
+out_superpixels = _slic(SLIC(n_segments=100, compactness=10.0, max_iter=10, enforce_connectivity=false),
+                        input_image)
+save("foo.png", synthesize(out_superpixels))

--- a/src/SuperPixels.jl
+++ b/src/SuperPixels.jl
@@ -15,6 +15,6 @@ export
     imsize,
     # algorithms
     synthesize, Raw, Average,
-    analyze, SLIC
+    analyze, SLIC, _slic
 
 end

--- a/src/analyze.jl
+++ b/src/analyze.jl
@@ -226,7 +226,7 @@ function _slic(alg::SLIC, img::AbstractArray{<:Lab, 2})
 
                 # merge the superpixel to its neighbor if it is too small
                 if current_segment_size < min_size
-                    @inbounds @simd for i = 1:current_segment_size
+                    for i = 1:current_segment_size
 
                         nearest_segments_final[coord_list[i, 1],
                                      coord_list[i, 2]] = adjacent
@@ -241,9 +241,9 @@ function _slic(alg::SLIC, img::AbstractArray{<:Lab, 2})
     end
 
 
-    open("superpixels_100_10_compat.txt", "w") do io
-        writedlm(io, nearest_segments,' ')
-    end
+    #open("superpixels_100_10_compat.txt", "w") do io
+    #    writedlm(io, nearest_segments,' ')
+    #end
 
     sp_img = map(1:n_segments) do i
         SuperPixel(img, findall(nearest_segments .== i))

--- a/src/analyze.jl
+++ b/src/analyze.jl
@@ -157,8 +157,84 @@ function _slic(alg::SLIC, img::AbstractArray{<:Lab, 2})
         segments ./= n_segment_elems # broadcast: (n_segments,) -> (n_segments, 5)
     end
 
+    # Enforce connectivity
+    # Reference: https://github.com/scikit-image/scikit-image/blob/7e4840bd9439d1dfb6beaf549998452c99f97fdd/skimage/segmentation/_slic.pyx#L240-L348
     if alg.enforce_connectivity
-        nothing # TODO
+        println("zergling")
+        segment_size = height * width / n_segments
+        min_size = 0.5 * segment_size
+        max_size = 3.0 * segment_size
+
+        dy = [1, -1, 0, 0]
+        dx = [0, 0, 1, -1]
+        # dz = [] # reversed for supervoxels
+
+        start_label = 1
+        mask_label = start_label - 1 # indicates the label of this pixel has not been assigned
+        nearest_segments_final = fill(mask_label, height, width)
+        current_new_label = start_label
+
+        # used for BFS
+        current_segment_size = 1
+        bfs_visited = 0
+
+        # store neighboring pixels
+        # now set the dimension to 2 because we are using superpixel
+        coord_list = fill(0, max_size, 2)
+ 
+        for x = 1:width
+            for y = 1:height
+                if nearest_segments[y, x] == mask_label continue end
+                if [y, x] > mask_label continue end
+
+                adjacent = 0
+                label = nearest_segments[y, x]
+                nearest_segments_final[y, x] = current_new_label
+                current_segment_size = 1
+                bfs_visited = 0
+                coord_list[bfs_visited + 1, 1] = y
+                coord_list[bfs_visited + 1, 2] = x
+
+                # Preform BFS to find the size of superpixel with 
+                # same lable number
+                while bfs_visited < current_segment_size < max_size
+                    for i = 1:4
+                        yy = coord_list[bfs_visited + 1, 1] + dy[i]
+                        xx = coord_list[bfs_visited + 1, 2] + dx[i]
+
+                        if 1 <= yy <= height &&  1 <= xx <= width
+                            if nearest_segments[yy, xx] == label && nearest_segments_final[yy, xx] == mask_label
+                                nearest_segments_final[yy, xx] = current_new_label
+                                coord_list[current_segment_size, 1] = yy # <-- index problem in the future
+                                coord_list[current_segment_size, 2] = xx # <-- index problem in the future
+                                current_segment_size += 1
+                                
+                                if current_segment_size >= max_size break end
+                            elseif nearest_segments_final[yy, xx] > mask_label &&
+                                   nearest_segments_final[yy, xx] != current_new_label
+                                adjacent = nearest_segments_final[yy, xx]
+                            end
+                        end
+                    end
+                    bfs_visited += 1
+                end
+
+                #for i = 1:current_segment_size println(coord_list[i, 1]) end
+                #println(max_size, " ", current_segment_size)
+
+                # merge the superpixel to its neighbor if it is too small
+                if current_segment_size < min_size
+                    for i = 1:current_segment_size
+                        #println(i, " ", coord_list[i, 1])
+                        nearest_segments_final[coord_list[i, 1],
+                                     coord_list[i, 2]] = adjacent
+                    end
+                else
+                    current_new_label += 1
+                end
+            end
+        end
+        nearest_segments = copy(nearest_segments_final)
     end
 
     sp_img = map(1:n_segments) do i

--- a/src/analyze.jl
+++ b/src/analyze.jl
@@ -226,7 +226,7 @@ function _slic(alg::SLIC, img::AbstractArray{<:Lab, 2})
 
                 # merge the superpixel to its neighbor if it is too small
                 if current_segment_size < min_size
-                    @inbound @simd for i = 1:current_segment_size
+                    @inbounds @simd for i = 1:current_segment_size
 
                         nearest_segments_final[coord_list[i, 1],
                                      coord_list[i, 2]] = adjacent

--- a/test/analyze.jl
+++ b/test/analyze.jl
@@ -1,9 +1,10 @@
 @testset "CreateSuperpixels" begin
     input_image = load("../lenna.bmp")
     #println(color_type(eltype(input_image)))
+    @btime _slic(SLIC(; n_segments=500, compatness=40.0, enforce_connectivity=true), Lab.($input_image))
     #out_superpixels = _slic(SLIC(; n_segments=100, compatness=10.0, enforce_connectivity=true), Lab.(input_image))
-    out_superpixels = _slic(SLIC(; n_segments=500, compatness=40.0, enforce_connectivity=true), Lab.(input_image))
-    synthesize(out_superpixels, Raw())
+    #out_superpixels = _slic(SLIC(; n_segments=500, compatness=40.0, enforce_connectivity=true), Lab.(input_image))
+    #synthesize(out_superpixels, Raw())
     #out_superpixels = analyze(slic_handle,
     #                          input_image)
     #save("foo.png", synthesize(out_superpixels))

--- a/test/analyze.jl
+++ b/test/analyze.jl
@@ -1,0 +1,7 @@
+@testset "CreateSuperpixels" begin
+    input_image = load("../lenna.bmp")
+    #out_superpixels = _slic(SLIC(n_segments=100, compatness=10.0, max_iter=10, enforce_connectivity=false),
+    #                    input_image)
+    out_superpixels = SLIC(n_segments=100, compatness=10.0, max_iter=10, enforce_connectivity=false)
+    save("foo.png", synthesize(out_superpixels))
+end

--- a/test/analyze.jl
+++ b/test/analyze.jl
@@ -1,8 +1,8 @@
 @testset "CreateSuperpixels" begin
     input_image = load("../lenna.bmp")
     #println(color_type(eltype(input_image)))
-    out_superpixels = _slic(SLIC(; enforce_connectivity=false),
-                        Lab.(input_image))
+    out_superpixels = _slic(SLIC(; n_segments=100, compatness=10.0, enforce_connectivity=true), Lab.(input_image))
+    #out_superpixels = _slic(SLIC(; n_segments=400, compatness=60.0, enforce_connectivity=true), Lab.(input_image))
     synthesize(out_superpixels, Raw())
     #out_superpixels = analyze(slic_handle,
     #                          input_image)

--- a/test/analyze.jl
+++ b/test/analyze.jl
@@ -1,7 +1,10 @@
 @testset "CreateSuperpixels" begin
     input_image = load("../lenna.bmp")
-    #out_superpixels = _slic(SLIC(n_segments=100, compatness=10.0, max_iter=10, enforce_connectivity=false),
-    #                    input_image)
-    out_superpixels = SLIC(n_segments=100, compatness=10.0, max_iter=10, enforce_connectivity=false)
-    save("foo.png", synthesize(out_superpixels))
+    #println(color_type(eltype(input_image)))
+    out_superpixels = _slic(SLIC(; enforce_connectivity=false),
+                        Lab.(input_image))
+    synthesize(out_superpixels, Raw())
+    #out_superpixels = analyze(slic_handle,
+    #                          input_image)
+    #save("foo.png", synthesize(out_superpixels))
 end

--- a/test/analyze.jl
+++ b/test/analyze.jl
@@ -1,8 +1,8 @@
 @testset "CreateSuperpixels" begin
     input_image = load("../lenna.bmp")
     #println(color_type(eltype(input_image)))
-    out_superpixels = _slic(SLIC(; n_segments=100, compatness=10.0, enforce_connectivity=true), Lab.(input_image))
-    #out_superpixels = _slic(SLIC(; n_segments=400, compatness=60.0, enforce_connectivity=true), Lab.(input_image))
+    #out_superpixels = _slic(SLIC(; n_segments=100, compatness=10.0, enforce_connectivity=true), Lab.(input_image))
+    out_superpixels = _slic(SLIC(; n_segments=500, compatness=40.0, enforce_connectivity=true), Lab.(input_image))
     synthesize(out_superpixels, Raw())
     #out_superpixels = analyze(slic_handle,
     #                          input_image)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using ImageCore
+using ImageCore, Images
 using Test, Suppressor
 
 refambs = @suppress_out detect_ambiguities(ImageCore, Base)
@@ -11,6 +11,7 @@ ambs = @suppress_out detect_ambiguities(ImageCore, Base, SuperPixels)
 
     include("types.jl")
     include("synthesize.jl")
+    include("analyze.jl")
 end
 
 nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,8 +9,8 @@ ambs = @suppress_out detect_ambiguities(ImageCore, Base, SuperPixels)
     # check if SuperPixels.jl introduces new ambiguities
     @test isempty(setdiff(ambs, refambs))
 
-    include("types.jl")
-    include("synthesize.jl")
+    #include("types.jl")
+    #include("synthesize.jl")
     include("analyze.jl")
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using ImageCore, Images
 using Test, Suppressor
 
 using DelimitedFiles
+using BenchmarkTools
 
 refambs = @suppress_out detect_ambiguities(ImageCore, Base)
 using SuperPixels

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using ImageCore, Images
 using Test, Suppressor
 
+using DelimitedFiles
+
 refambs = @suppress_out detect_ambiguities(ImageCore, Base)
 using SuperPixels
 ambs = @suppress_out detect_ambiguities(ImageCore, Base, SuperPixels)


### PR DESCRIPTION
Add enforce connectivity feature in analyze method.
The enforce connectivity implementation is based on [scikit-image](https://github.com/scikit-image/scikit-image/blob/7e4840bd9439d1dfb6beaf549998452c99f97fdd/skimage/segmentation/_slic.pyx#L240-L348).

Because the original implementation uses 0-indexing, so I tried to translate into 1-indexing.
Though so far there are no any problems about `unbounded error`, it is ought to conduct test because I think
the implementation still have some problems in BFS part.

Feel free to edit and delete file changes. I am first time to Julia development, so I use some dirty ways to let
the test run.