### PR TITLE
[WIP] rework SuperPixel and SuperPixelImage with Array interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,18 +4,18 @@ authors = ["Johnny Chen <johnnychen94@hotmail.com>"]
 version = "0.0.1"
 
 [deps]
-ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
-ImageDraw = "4381153b-2b60-58ae-a1ba-fd683676385f"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-ImageCore = ">=0.8.5"
+ColorVectorSpace = "0.7, 0.8"
+ImageCore = "0.8.5"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Suppressor"]

--- a/src/SuperPixels.jl
+++ b/src/SuperPixels.jl
@@ -1,17 +1,15 @@
 module SuperPixels
 
-using ImageCore, ColorVectorSpace
+using Base: tail
 using Statistics
-import ColorTypes: color_type, color
-import Base: position
+using FillArrays
+using ImageCore, ColorVectorSpace
 
 include("types.jl")
 include("synthesize.jl")
 
 export
-    SuperPixel, color, position,
-    # utils
-    imsize,
+    SuperPixel,
     # algorithms
     synthesize, Raw, Average
 

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -1,17 +1,34 @@
+# An intermediate helper class for synthesize
+struct SuperPixelImage{C, N, AT<:AbstractArray{<:SuperPixel}} <: AbstractArray{C, N}
+    tiles::AT
+
+    axes::NTuple{N, UnitRange{Int}}
+    function SuperPixelImage(tiles::SPI) where SPI<:AbstractArray{<:SuperPixel}
+        C = eltype(eltype(SPI))
+        N = ndims(eltype(SPI))
+        new{C, N, SPI}(tiles, _spi_axes(axes.(tiles)...))
+    end
+end
+SuperPixelImage(img::SuperPixelImage) = img
+
+@inline _spi_axes(indices...) = __spi_axes(first(indices), tail(indices))
+@inline function __spi_axes(R1, indices::Tuple)
+    # TODO: accelerate this?
+    R2 = first(indices)
+    R = ntuple(length(R1)) do i
+        r1, r2 = R1[i], R2[i]
+        min(first(r1), first(r2)):max(last(r1), last(r2))
+    end
+    __spi_axes(R, tail(indices))
+end
+@inline __spi_axes(R, indices::Tuple{}) = R
+
+@inline Base.axes(spi::SuperPixelImage) = spi.axes
+@inline Base.size(spi::SuperPixelImage) = length.(spi.axes)
+
+### synthesize
+
 abstract type AbstractSynthesizeMethod end
-
-"""
-    Raw <: AbstractSynthesizeMethod
-
-Pixel values inside SuperPixel is not changed.
-"""
-struct Raw <: AbstractSynthesizeMethod end
-"""
-    Mean <: AbstractSynthesizeMethod
-
-Pixel values inside SuperPixel is averaged.
-"""
-struct Average <: AbstractSynthesizeMethod end
 
 """
     synthesize([CT], img, [method=Raw()])
@@ -19,38 +36,64 @@ struct Average <: AbstractSynthesizeMethod end
 Collect pixels in `img` and returns an image of type `Array{CT}`.
 
 Argument `method` controls how pixels are collected, supported methods
-are [`Raw`](@ref) and [`Average`](@ref). The default value is `Raw`.
-
-!!! note
-    Overlaps between superpixels are averaged. Empty pixels are filled
-    by zeros.
+are [`Raw`](@ref) and [`Average`](@ref). The default value is `Raw()`.
 """
-synthesize(img::AbstractArray{<:SuperPixel}, method = Raw()) =
-    synthesize(color_type(img), img, method)
-synthesize(::Type{T}, img::AbstractArray{<:SuperPixel}, method = Raw()) where T =
-    synthesize(T, img, method)
+function synthesize(img::AbstractArray, args...; kwargs...)
+    img = SuperPixelImage(img)
+    synthesize(eltype(img), img, args...; kwargs...)
+end
+synthesize(::Type{T}, img::AbstractArray, args...; kwargs...) where T =
+    synthesize(T, SuperPixelImage(img), args...; kwargs...)
+synthesize(::Type{T}, img::SuperPixelImage, method=Raw(img), args...; kwargs...) where T =
+    synthesize(T, img, method, args...; kwargs...)
 
-function synthesize(::Type{CT},
-                    img::AbstractArray{<:SuperPixel},
-                    ::Raw) where CT <: Union{AbstractRGB, AbstractGray}
+"""
+    Raw <: AbstractSynthesizeMethod
+    Raw(fillvalue=0)
 
-    out = zeros(CT, imsize(img))
-    count = zeros(Int, imsize(img)) # overlap count
-    for SP in img
-        isempty(SP) && continue
-        R = position(SP)
-        out[R] .+= color(SP)
+Pixel values inside SuperPixel is not changed.
+
+Overlaps between superpixels are averaged. Missing pixels are filled by `fillvalue`.
+"""
+struct Raw{C<:Union{Number, Colorant}} <: AbstractSynthesizeMethod
+    fillvalue::C
+end
+Raw() = Raw(0)
+Raw(img::SuperPixelImage) = Raw(zero(eltype(img)))
+
+function synthesize(::Type{T}, img::SuperPixelImage, S::Raw) where T
+    out = zeros(T, size(img))
+    count = zeros(Int, size(img)) # overlap counts
+
+    for sp in img.tiles
+        isempty(sp) && continue
+        R = CartesianIndices(sp.indices)
+        out[R] .+= @view sp.values[R]
         count[R] .+= 1
     end
+
+    R = count.==0
+    out[R] .= S.fillvalue
+    count[R] .= 1
     return out./count
 end
 
-function synthesize(::Type{CT},
-                    img::AbstractArray{<:SuperPixel},
-                    ::Average) where CT <: Union{AbstractRGB, AbstractGray}
-    averaged_img = map(img) do SP
-        SuperPixel(fill(mean(SP.color), size(SP.color)),
-                   position(SP))
+"""
+    Mean <: AbstractSynthesizeMethod
+    Mean(fillvalue=0)
+
+Pixel values inside SuperPixel is averaged.
+
+Overlaps between superpixels are averaged. Missing pixels are filled by `fillvalue`.
+"""
+struct Average <: AbstractSynthesizeMethod
+    fillvalue
+end
+Average() = Average(0)
+
+function synthesize(::Type{T}, img::SuperPixelImage, S::Average) where T
+    averaged_img = map(img.tiles) do sp
+        SuperPixel(Fill(mean(sp), axes(sp)), axes(sp))
     end
-    return synthesize(CT, averaged_img, Raw())
+    return synthesize(T, averaged_img, Raw(S.fillvalue))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,15 +1,9 @@
 using ImageCore
 using Test, Suppressor
-
-refambs = @suppress_out detect_ambiguities(ImageCore, Base)
 using SuperPixels
-ambs = @suppress_out detect_ambiguities(ImageCore, Base, SuperPixels)
 
 @testset "SuperPixels.jl" begin
-    # check if SuperPixels.jl introduces new ambiguities
-    @test isempty(setdiff(ambs, refambs))
-
-    include("types.jl")
+    # include("types.jl")
     include("synthesize.jl")
 end
 


### PR DESCRIPTION
The reasoning behind this rework:

- a superpixel is a collection of pixels (values and indices)
  - `values` is an array of colorants
  - `indices` can be tuple of ranges, `CartesianIndices`, or even a [tile](https://github.com/JuliaArrays/TiledIteration.jl/pull/27)
- lazily do `getindex(::SuperPixel, inds...)` for both simplicity and performance.